### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dreamluau"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Y0SH1M4S73R <legoboyo@earthlink.net>"]
 edition = "2021"
 


### PR DESCRIPTION
This is just to make it easier for yoshi or mothblocks to trigger a build and release workflow so we can deploy the build fix downstream.