### PR TITLE
Add isolated lua states

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,9 @@ pub(crate) mod wrappers;
 
 pub use state::{
     awaken, call_function, clear_execution_limit, clear_ref_userdata, collect_garbage, get_globals,
-    get_traceback, kill_sleeping_thread, kill_state, kill_yielded_thread, list_threads, load,
-    new_state, resume, set_execution_limit_millis, set_execution_limit_secs, set_usr,
+    get_traceback, is_isolated, kill_sleeping_thread, kill_state, kill_yielded_thread,
+    list_threads, load, new_state, resume, set_execution_limit_millis, set_execution_limit_secs,
+    set_usr,
 };
 
 pub use wrappers::{

--- a/src/value/conversion/into.rs
+++ b/src/value/conversion/into.rs
@@ -82,6 +82,12 @@ impl<'lua> IntoLua<'lua> for Value {
                 .into_printed_external()?
                 .into_lua(lua);
         };
-        get_or_create_cached_userdata(self, lua)?.into_lua(lua)
+        // If isolated, never allow any sort of userdata to be exposed.
+        let isolate = lua.named_registry_value::<bool>("isolated")?;
+        if isolate {
+            Ok(LuaValue::Nil)
+        } else {
+            get_or_create_cached_userdata(self, lua)?.into_lua(lua)
+        }
     }
 }


### PR DESCRIPTION
This adds isolated Lua states, intended for use with untrusted code (my intent is to try to use this to replace NTSL on MonkeStation)

An isolated state can be created by passing TRUE as an argument to `new_state`. This is not a breaking change - if no argument is given, it will default to a normal, non-isolated state.

A new exported function is also available, `is_isolated`, which is exactly what it says on the tin, it just returns true/false if the given state is isolated or not.

State isolation is store as a boolean registry value named `isolated`.

Isolated states do not have the `dm`, `list`, or `pointer` modules, and any sort of userdata will just be converted to nil.